### PR TITLE
 Add interface auto-detection on Linux.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ if (IS_REDHAT )
   add_definitions(-D_HAVE_NCURSES)
 endif()
 
+add_definitions(-D_HAVE_CHECKINTERFACE)
 add_executable(slurm ${SLURM_SOURCES})
 
 target_link_libraries(slurm ncurses)

--- a/slurm.c
+++ b/slurm.c
@@ -1263,7 +1263,7 @@ int main(int argc, char *argv[])
         fprintf(stderr, "specified device does not exist or cannot "
                 "be monitored!\n\nIf you think this is an error please report "
                 "it to https://github.com/mattthias/slurm/issues . Thanks!\n");
-		exit(1);
+        exit(1);
     }
 
     /* Initialize some info variables */

--- a/slurm.c
+++ b/slurm.c
@@ -1240,8 +1240,24 @@ int main(int argc, char *argv[])
         }
     }
 
-    if (strlen(ifdata.if_name) == 0)
+    if (strlen(ifdata.if_name) == 0) {
+#ifdef __linux__
+        /* If no interface was given as option make an educated guess for a default interface */
+        int rv = get_default_interface(&ifdata);
+        if (rv == 0) {
+            validinterface = checkinterface();
+        } else {
+            fprintf(stderr,
+                    "\nNo network interface given on command line and auto-detect failed.\n"
+                    "Please specify a network interface using \"-i <iface>\".\n\n",
+                    REFRESH_MIN, REFRESH_MAX);
+            usage(1, argv);
+
+        }
+#else
         usage(1, argv);
+#endif
+    }
 
     if (!validinterface) {
         fprintf(stderr, "specified device does not exist or cannot "

--- a/src/linux.c
+++ b/src/linux.c
@@ -99,3 +99,60 @@ int get_stat(void)
     }
     return (interfacefound == 1) ? 0 : 1;
 }
+
+
+/*****************************************************************************
+ *
+ *  get_default_interface()
+ *
+ *  If only one non local interface is up use that as default
+ *
+ ****************************************************************************/
+int get_default_interface(IfData * ifdata)
+{
+
+
+    struct if_nameindex *ifs;
+    ifs = if_nameindex();
+
+    struct ifreq ifr;
+    unsigned int i;
+    unsigned int iface_up = 0;
+    char iface_up_name[IFNAMSIZ];
+
+
+    /* Create a socket to ioctl on */
+    int sk = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
+
+    /* get an array of if_nameindex structs (one for each iface) */
+    ifs = if_nameindex();
+
+    /* iterate over the array and .. */
+    for (i = 0; ifs[i].if_index; i++) {
+
+        /* skip local loopback */
+        if (!strcmp(ifs[i].if_name, "lo")) {
+            continue;
+        }
+
+        /* write the name of the iface we want to check into the ifr struct and .. */
+        strncpy(ifr.ifr_name, ifs[i].if_name, IFNAMSIZ);
+
+        /* .. perform an ioctl SIOCGIFFLAGS to get the iface flags */
+        ioctl(sk, SIOCGIFFLAGS, &ifr);
+
+        /* check if the iface is up (IFF_UP is set) */
+        if (ifr.ifr_flags & IFF_UP) {
+            iface_up++;
+            strncpy(iface_up_name, ifr.ifr_name, IFNAMSIZ);
+        }
+    }
+
+    if (iface_up == 1) {
+        snprintf((char *) ifdata->if_name,
+                 (size_t) sizeof(ifdata->if_name), "%s", iface_up_name);
+        return (0);
+    }
+
+    return (2);
+}


### PR DESCRIPTION


 This pull request addresses issue #5 "If no interface is specified, default
  to an up non-local interface".

  slurm defaults now to the only non-loopback and up interface.
  If more than one interface up it quits with a warning.

 Thanks to @tixxdz  for the help! 