### PR TITLE
correct typo BUFSIZ to BUFSIZE

### DIFF
--- a/src/linux.c
+++ b/src/linux.c
@@ -65,11 +65,11 @@ int get_stat(void)
 
     /* do not parse the first two lines as they only contain static garbage */
     fseek(proc_net_dev, 0, SEEK_SET);
-    fgets(buffer, BUFSIZ - 1, proc_net_dev);
-    fgets(buffer, BUFSIZ - 1, proc_net_dev);
+    fgets(buffer, BUFSIZE - 1, proc_net_dev);
+    fgets(buffer, BUFSIZE - 1, proc_net_dev);
 
     interfacefound = 0;
-    while (fgets(buffer, BUFSIZ - 1, proc_net_dev) != NULL) {
+    while (fgets(buffer, BUFSIZE - 1, proc_net_dev) != NULL) {
         /* find the device name and substitute ':' with '\0' */
         ptr = buffer;
         while (*ptr == ' ')


### PR DESCRIPTION
This was found using [LGTM.com](https://lgtm.com/projects/g/mattthias/slurm/snapshot/e3e87c7c906efeb42d5c0908401cbb6a5d18d6ef/files/src/linux.c#xe47e30e8ca363ac0:1), there are some other findings [here](https://lgtm.com/projects/g/mattthias/slurm/alerts/?mode=list) and you can [enable automated PR analysis](https://lgtm.com/projects/g/mattthias/slurm/ci/) to guard against new issues being introduced.

Full disclosure: I work for Semmle, the company behind LGTM.com.
