### PR TITLE
implement iface speed detection on Linux (closes #12)

### DIFF
--- a/slurm.c
+++ b/slurm.c
@@ -1300,7 +1300,7 @@ int main(int argc, char *argv[])
      * if the speed could not determined due to errors or lack of
      * this feature on the host operating system
      */
-#if defined(_HAVE_BSD) || defined(__HPUX__) || defined(__Solaris__) || defined(__APPLE__)
+#if defined(_HAVE_BSD) || defined(__HPUX__) || defined(__Solaris__) || defined(__APPLE__) || defined(__linux__)
     ifdata.if_speed = get_if_speed(ifdata.if_name);
 
     /* if ERR_IFACE_NO_SPEED we could not determine the interface speed


### PR DESCRIPTION
This follows the deprecated SIOCETHTOOL interface, but should be
generally more portable. Was tested on Debian GNU/Linux "buster" with
a 4.18.0 Linux kernel.

Note that the interface is similar to the the BSD media.h pattern
(create a socket and pass it to ioctl) but I felt it was clearer to
just create another #if block than mangle the already quite complex

This was mostly cargo-culted from:

https://stackoverflow.com/questions/2872058/get-link-speed-programmatically