### PR TITLE
fix man page documentation for -d

### DIFF
--- a/slurm.1
+++ b/slurm.1
@@ -30,7 +30,7 @@ start slurm in large split graph mode
 .It Fl z
 virtually zero traffic counters instead of showing values stored in kernel
 .It Fl d Ar delay
-delay between screen updates in milliseconds (1000 = once per second)
+delay between screen updates in seconds (must be between 1 and 300)
 .It Fl i Ar interface
 select interface to monitor (required)
 .El


### PR DESCRIPTION
delay is in seconds; documentation claims milliseconds.