### PR TITLE
Ensure correct linking against ncurses

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ endif()
 add_definitions(-D_HAVE_CHECKINTERFACE)
 add_executable(slurm ${SLURM_SOURCES})
 
-target_link_libraries(slurm ncurses)
+target_link_libraries(slurm ${CURSES_LIBRARY} ${CURSES_EXTRA_LIBRARY})
 
 # install
 install(TARGETS slurm DESTINATION bin)


### PR DESCRIPTION
find_package will populate variables to ensure we link
against the correct libraries for a package. In the case
of ncurses, it's possible we need to link against
e.g. -ltinfo too.