### PR TITLE
Incorporate OpenBSD ports patches

### DIFF
--- a/src/if_media.c
+++ b/src/if_media.c
@@ -55,7 +55,7 @@ int get_if_speed(char *ifstring)
     int speed = ERR_IFACE_NO_SPEED;
     int s;                      /* socket */
     struct ifmediareq ifmr;
-    int *media_list;
+    uint64_t *media_list;
     int type, physical;
 
     if ((s = socket(AF_INET, SOCK_DGRAM, 0)) == -1) {
@@ -77,7 +77,7 @@ int get_if_speed(char *ifstring)
         return ERR_IFACE_NO_SPEED;
     }
 
-    media_list = (int *) malloc(ifmr.ifm_count * sizeof(int));
+    media_list = (uint64_t *) malloc(ifmr.ifm_count * sizeof(uint64_t));
     if (media_list == NULL)
         fprintf(stderr, "malloc() error in if_media.c\n");
     ifmr.ifm_ulist = media_list;
@@ -96,8 +96,16 @@ int get_if_speed(char *ifstring)
      *
      */
 
+#ifdef IFM_TYPE
+    type = IFM_TYPE(ifmr.ifm_active);
+#else
     type = ifmr.ifm_active & 0xf0;
+#endif
+#ifdef IFM_TYPE
+    physical = IFM_SUBTYPE(ifmr.ifm_active);
+#else
     physical = ifmr.ifm_active & 0x0f;
+#endif
 
 #ifdef MEDIADEBUG
     printf("      all: %6d\n", ifmr.ifm_current);
@@ -184,7 +192,8 @@ int get_if_speed(char *ifstring)
 #endif
 #if WIRELESS && \
 	(defined(__FreeBSD__) && (__FreeBSD_version >= 500111)) || \
-	(defined(__NetBSD__) && (__NetBSD_Version_ > 106020000))
+	(defined(__NetBSD__) && (__NetBSD_Version_ > 106020000)) || \
+        defined(__OpenBSD__)
         case IFM_IEEE80211_OFDM6:
             speed = 6 * 1000;
             break;

--- a/src/openbsd.c
+++ b/src/openbsd.c
@@ -119,7 +119,7 @@ int get_stat(void)
             /* search for the right network interface */
             if (sdl->sdl_family != AF_LINK)
                 continue;
-            if (strcmp(sdl->sdl_data, ifdata.if_name) != 0)
+            if (strncmp(sdl->sdl_data, ifdata.if_name, sdl->sdl_nlen) != 0)
                 continue;
             strncpy(s, sdl->sdl_data, sdl->sdl_nlen);
             s[sdl->sdl_nlen] = '\0';


### PR DESCRIPTION
To make "upstream" slurm work on OpenBSD the following patches from the
OpenBSD ports repository where incorporated:

Authored by Stuart Henderson (sthen@)
https://cvsweb.openbsd.org/cgi-bin/cvsweb/~checkout~/ports/net/slurm/patches/patch-src_if_media_c?rev=1.3

Authored by David Coppa (dcoppa@)
https://cvsweb.openbsd.org/cgi-bin/cvsweb/~checkout~/ports/net/slurm/patches/patch-src_openbsd_c?rev=1.2

Signed-off-by: Matthias Schmitz <matthias@sigxcpu.org>