### PR TITLE
Use "curses" as dependency to work on OpenBSD and everywhere

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,11 +1,15 @@
 project('slurm', 'c')
 
+
+# We want ncurses but meson wraps ncurses and curses into the curses dependency
+# https://mesonbuild.com/Dependencies.html#curses
+# dependency "ncurses" doesn't work on OpenBSD so we use "curses" on all OS
+curses_dep = dependency('curses', version: '>=5')
+
 add_global_arguments('-D_HAVE_NCURSES', language: 'c')
 
-ncurses_dep = dependency('ncurses', version: '>=5') 
-
 # build and install slurm binary
-executable('slurm', 'slurm.c', dependencies: ncurses_dep, install:true )
+executable('slurm', 'slurm.c', dependencies: curses_dep, install:true )
 
 # install manpage and theme files
 install_man('slurm.1')


### PR DESCRIPTION
On OpenBSD "ncurses" is named "curses" so the old dependency didn't work there. Meson wraps curses and ncurses into the "curses" dependency with preference on ncurses. Perfect!

Signed-off-by: Matthias Schmitz <matthias@sigxcpu.org>